### PR TITLE
Fix EMEController race condition between media encrypted event and key session creation

### DIFF
--- a/src/controller/eme-controller.js
+++ b/src/controller/eme-controller.js
@@ -163,6 +163,11 @@ class EMEController extends EventHandler {
       })
       .catch((err) => {
         logger.error(`Failed to obtain key-system "${keySystem}" access:`, err);
+        this.hls.trigger(Event.ERROR, {
+          type: ErrorTypes.KEY_SYSTEM_ERROR,
+          details: ErrorDetails.KEY_SYSTEM_NO_ACCESS,
+          fatal: true
+        });
       });
   }
 
@@ -203,6 +208,11 @@ class EMEController extends EventHandler {
       })
       .catch((err) => {
         logger.error('Failed to create media-keys:', err);
+        this.hls.trigger(Event.ERROR, {
+          type: ErrorTypes.KEY_SYSTEM_ERROR,
+          details: ErrorDetails.KEY_SYSTEM_NO_KEYS,
+          fatal: true
+        });
       });
   }
 
@@ -227,6 +237,7 @@ class EMEController extends EventHandler {
   _onNewMediaKeySession (keySession) {
     logger.log(`New key-system session ${keySession.sessionId}`);
 
+    this.hls.startLoad();
     keySession.addEventListener('message', (event) => {
       this._onKeySessionMessage(keySession, event.message);
     }, false);
@@ -516,6 +527,7 @@ class EMEController extends EventHandler {
     const audioCodecs = data.levels.map((level) => level.audioCodec);
     const videoCodecs = data.levels.map((level) => level.videoCodec);
 
+    this.hls.stopLoad();
     this._attemptKeySystemAccess(KeySystems.WIDEVINE, audioCodecs, videoCodecs);
   }
 }


### PR DESCRIPTION
### This PR will...

In some low-end devices we found that sometimes the media key request and key session creation process take longer (up to 8s as we tested) than the media loading and first `encrypted` event, which by default will throw a fatal error and no playback.

This PR aims to fix that race condition case, the solution is:

1. call `stopLoad` method to suspend level manifest and media file requests when starting to request media key access
2. throw fatal errors if media key request or key session creation fails, similar to the current logic in `_generateRequestWithPreferredKeySession`
3. call `startLoad` to resume level manifest and media file requests when the player is ready to decrypt DRM media resources

As tested in FireTV Stick, it could work for every title now:

<img width="1033" alt="Screen Shot 2020-02-24 at 3 51 31 PM" src="https://user-images.githubusercontent.com/687412/75136332-57fca800-571f-11ea-94ee-5c68a3322d3c.png">

We first tried another approach, wait until key session is created in the `_onMediaEncrypted` through an event. But sometimes it caused another problem: a fatal `BUFFER_STALLED_ERROR` error due to long buffering time because Hls.js counted the waiting time into buffering time, it even tried to nudge in order to get rid of the stall which accelerated the problem.

One drawback of this solution is media resource suspension, as we tested, normally it takes less than 1s to finish the media key access request and key session creation process.

### Why is this Pull Request needed?

As the previous section mentioned, this PR could fix the race condition case in EMEController, which causes fatal errors and block playback.

### Are there any points in the code the reviewer needs to double check?

No.

### Resolves issues:

N/A

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
