### PR TITLE
Support DRM advanced configurations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tubitv/hls.js",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/config.js
+++ b/src/config.js
@@ -89,6 +89,7 @@ export var hlsDefaultConfig = {
   minAutoBitrate: 0, // used by hls
   emeEnabled: false, // used by eme-controller
   widevineLicenseUrl: undefined, // used by eme-controller
+  drmSystemOptions: undefined, // used by eme-controller
   requestMediaKeySystemAccessFunc:
             requestMediaKeySystemAccess // used by eme-controller
 };


### PR DESCRIPTION
### This PR will...

This PR makes Hls.js be able to configure `videoRobustness` and `audioRobustness` options which could help us to specify `robustness` during requesting media key system access.

### Why is this Pull Request needed?

In FireTV HDCP issue troubleshooting, we find that we need to use `robustness` settings in order to make the playback work with Hls.js. But Hls.js doesn't support any DRM configuration at all.

### Are there any points in the code the reviewer needs to double check?

No.

### Resolves issues:

N/A

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
