### PR TITLE
Playready Integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "hls.js",
+  "name": "@tubitv/hls.js",
   "license": "Apache-2.0",
+  "version": "1.0.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",
   "authors": "Guillaume du Pontavice <g.du.pontavice@gmail.com>",

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,7 @@ export type EMEControllerConfig = {
   licenseXhrSetup?: (xhr: XMLHttpRequest, url: string) => void,
   emeEnabled: boolean,
   widevineLicenseUrl?: string,
+  playreadyLicenseUrl?: string;
   requestMediaKeySystemAccessFunc: MediaKeyFunc | null,
 };
 
@@ -123,6 +124,8 @@ type TimelineControllerConfig = {
 type TSDemuxerConfig = {
   forceKeyFrameOnDiscontinuity: boolean,
 };
+
+console.log('** I AM CONFIG TEST **');
 
 export type HlsConfig =
   {
@@ -234,6 +237,7 @@ export const hlsDefaultConfig: HlsConfig = {
   minAutoBitrate: 0, // used by hls
   emeEnabled: false, // used by eme-controller
   widevineLicenseUrl: void 0, // used by eme-controller
+  playreadyLicenseUrl: void 0, // used by eme-controller
   requestMediaKeySystemAccessFunc: requestMediaKeySystemAccess, // used by eme-controller
 
   // Dynamic Modules

--- a/src/config.ts
+++ b/src/config.ts
@@ -125,8 +125,6 @@ type TSDemuxerConfig = {
   forceKeyFrameOnDiscontinuity: boolean,
 };
 
-console.log('** I AM CONFIG TEST **');
-
 export type HlsConfig =
   {
     debug: boolean,

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -171,7 +171,6 @@ class EMEController extends EventHandler {
     // expecting interface like window.navigator.requestMediaKeySystemAccess
     this.requestMediaKeySystemAccess(keySystem, mediaKeySystemConfigs)
       .then((mediaKeySystemAccess) => {
-        console.log('** _attemptKeySystemAccess **', mediaKeySystemAccess);
         this._onMediaKeySystemAccessObtained(keySystem, mediaKeySystemAccess);
       })
       .catch((err) => {
@@ -206,7 +205,6 @@ class EMEController extends EventHandler {
 
     mediaKeySystemAccess.createMediaKeys()
       .then((mediaKeys) => {
-        console.log('** _onMediaKeySystemAccessObtained **', mediaKeys);
         mediaKeysListItem.mediaKeys = mediaKeys;
 
         logger.log(`Media-keys created for key-system "${keySystem}"`);
@@ -283,8 +281,6 @@ class EMEController extends EventHandler {
 
     if (!this._hasSetMediaKeys) {
       // FIXME: see if we can/want/need-to really to deal with several potential key-sessions?
-      console.log('*** this._mediaKeysList *** ')
-      console.dir(this._mediaKeysList);
       const keysListItem = this._mediaKeysList[0];
       if (!keysListItem || !keysListItem.mediaKeys) {
         logger.error('Fatal: Media is encrypted but no CDM access or no keys have been obtained yet');
@@ -452,13 +448,10 @@ class EMEController extends EventHandler {
         // from https://github.com/MicrosoftEdge/Demos/blob/master/eme/scripts/demo.js
         // For PlayReady CDMs, we need to dig the Challenge out of the XML.
         var keyMessageXml = new DOMParser().parseFromString(String.fromCharCode.apply(null, new Uint16Array(keyMessage)), 'application/xml');
-        console.log('** keyMessageXml **');
-        console.log(keyMessageXml.toString());
         let challenge: ArrayBuffer | null = null;
         if (keyMessageXml.getElementsByTagName('Challenge')[0]) {
             // @ts-ignore
             challenge = atob(keyMessageXml.getElementsByTagName('Challenge')[0].childNodes[0].nodeValue);
-            console.log('** _generateLicenseRequestChallenge challenge **', challenge);
         } else {
             throw 'Cannot find <Challenge> in key message';
         }
@@ -506,7 +499,6 @@ class EMEController extends EventHandler {
       logger.log(`Sending license request to URL: ${url}`);
       this._xhr = xhr;
       const challenge = this._generateLicenseRequestChallenge(keysListItem, keyMessage);
-      console.log('** _requestLicense **', challenge);
       xhr.send(challenge);
     } catch (e) {
       console.error(e);
@@ -549,7 +541,6 @@ class EMEController extends EventHandler {
     const videoCodecs = data.levels.map((level) => level.videoCodec);
 
     const keySystem = this._widevineLicenseUrl ? KeySystems.WIDEVINE : KeySystems.PLAYREADY;
-    console.log('** keySystem **', keySystem, this._playreadyLicenseUrl);
     this._attemptKeySystemAccess(keySystem, audioCodecs, videoCodecs);
   }
 }

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -205,6 +205,7 @@ class EMEController extends EventHandler {
 
     mediaKeySystemAccess.createMediaKeys()
       .then((mediaKeys) => {
+        console.log('** mediaKeys **', mediaKeys);
         mediaKeysListItem.mediaKeys = mediaKeys;
 
         logger.log(`Media-keys created for key-system "${keySystem}"`);
@@ -457,6 +458,8 @@ class EMEController extends EventHandler {
         }
         var headerNames = keyMessageXml.getElementsByTagName('name');
         var headerValues = keyMessageXml.getElementsByTagName('value');
+        console.log('** headerNames **', headerNames);
+        console.log('** headerValues **', headerValues);
         if (headerNames.length !== headerValues.length) {
             throw 'Mismatched header <name>/<value> pair in key message';
         }
@@ -499,9 +502,9 @@ class EMEController extends EventHandler {
       logger.log(`Sending license request to URL: ${url}`);
       this._xhr = xhr;
       const challenge = this._generateLicenseRequestChallenge(keysListItem, keyMessage);
+      console.log('** challenge **', challenge);
       xhr.send(challenge);
     } catch (e) {
-      console.error(e);
       logger.error(`Failure requesting DRM license: ${e}`);
       this.hls.trigger(Event.ERROR, {
         type: ErrorTypes.KEY_SYSTEM_ERROR,


### PR DESCRIPTION
## Which problem does this PR solve?
Adds Playready DRM integration support to Hls.js player. It currently only supports WideVine DRM but with this PR it will support Playready as well.

## Main changes
- The main changes includes adding a config for `playreadyLicenseUrl`. If the user does not pass `widevineLicenseUrl` then we check for if `playreadyLicenseUrl` exists. 
- The challenge key generation process is different for playready. There is a demo app provided by Microsoft (https://github.com/MicrosoftEdge/Demos/blob/master/eme/scripts/demo.js) which shows a snippet on how to generate and use the challenge key for playready integration.
- A little bit of changes for log handling license request failures.

## Related documents/resources
https://app.clubhouse.io/tubi/story/96954/extend-hls-js-to-support-playready

## Suggested CR ordering of files?
emeController.ts

## Test Plan
- Tested on edge browser on a PC and this works fine but does not work on the emulator in browserstack. I do not know why.
- Tested on Comcast with playready and it does not work on Comcast device as well though the device claims that it has support for Microsoft and youtube playready keysystems. 