### PR TITLE
feat: using "keystatuseschange" event listener to ensure "usable" key status

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undefined */
+
 /**
  * HLS config
  */
@@ -20,6 +22,7 @@ import EMEController from './controller/eme-controller';
 
 import { requestMediaKeySystemAccess } from './utils/mediakeys-helper';
 
+// eslint-disable-next-line no-var
 export var hlsDefaultConfig = {
   autoStartLoad: true, // used by stream-controller
   startPosition: -1, // used by stream-controller
@@ -31,7 +34,6 @@ export var hlsDefaultConfig = {
   maxBufferLength: 30, // used by stream-controller
   maxBufferSize: 60 * 1000 * 1000, // used by stream-controller
   maxBufferHole: 0.5, // used by stream-controller
-
   lowBufferWatchdogPeriod: 0.5, // used by stream-controller
   highBufferWatchdogPeriod: 3, // used by stream-controller
   nudgeOffset: 0.1, // used by stream-controller
@@ -91,8 +93,8 @@ export var hlsDefaultConfig = {
   widevineLicenseUrl: undefined, // used by eme-controller
   playreadyLicenseUrl: undefined, // used by eme-controller
   drmSystemOptions: undefined, // used by eme-controller
-  requestMediaKeySystemAccessFunc:
-  requestMediaKeySystemAccess // used by eme-controller
+  requestMediaKeySystemAccessFunc: requestMediaKeySystemAccess, // used by eme-controller
+  minHdcpVersion: undefined // used by eme-controller
 };
 
 if (__USE_SUBTITLES__) {

--- a/src/controller/eme-controller.js
+++ b/src/controller/eme-controller.js
@@ -14,8 +14,6 @@ const { XMLHttpRequest } = window;
 
 const MAX_LICENSE_REQUEST_FAILURES = 3;
 
-const textDecoder = new TextDecoder();
-
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/requestMediaKeySystemAccess
  */
@@ -300,6 +298,8 @@ class EMEController extends EventHandler {
   _onKeySessionKeyStatusesChange (keySession) {
     logger.log('Got EME keystatuseschange event, detecting license status');
 
+    // `keyStatuses` is `Map`-like object connecting to the length of `KeyIds`,
+    // but every `keyStatuses` needs to be `usable` to continue.
     keySession.keyStatuses.forEach((status) => {
       if (status !== 'usable') {
         logger.error('Fatal error: Key session is not usable.');

--- a/src/controller/eme-controller.js
+++ b/src/controller/eme-controller.js
@@ -301,7 +301,7 @@ class EMEController extends EventHandler {
     // `keyStatuses` is `Map`-like object connecting to the length of `KeyIds`,
     // but every `keyStatuses` needs to be `usable` to continue.
     keySession.keyStatuses.forEach((status) => {
-      if (status !== 'usable') {
+      if (status === 'output-downscaled' || status === 'output-restricted') {
         logger.error('Fatal error: Key session is not usable.');
         this.hls.trigger(Event.ERROR, {
           type: ErrorTypes.KEY_SYSTEM_ERROR,

--- a/src/errors.js
+++ b/src/errors.js
@@ -16,6 +16,7 @@ export const ErrorTypes = {
  * @typedef {string} ErrorDetail
  */
 export const ErrorDetails = {
+  KEY_STATUSES_ERROR: 'keyStatusesError',
   KEY_SYSTEM_NO_KEYS: 'keySystemNoKeys',
   KEY_SYSTEM_NO_ACCESS: 'keySystemNoAccess',
   KEY_SYSTEM_NO_SESSION: 'keySystemNoSession',

--- a/src/errors.js
+++ b/src/errors.js
@@ -16,11 +16,12 @@ export const ErrorTypes = {
  * @typedef {string} ErrorDetail
  */
 export const ErrorDetails = {
-  KEY_STATUSES_ERROR: 'keyStatusesError',
-  KEY_SYSTEM_NO_KEYS: 'keySystemNoKeys',
-  KEY_SYSTEM_NO_ACCESS: 'keySystemNoAccess',
-  KEY_SYSTEM_NO_SESSION: 'keySystemNoSession',
+  KEY_SYSTEM_INVALID_HDCP_VERSION: 'keySystemInvalidHdcpVersion',
+  KEY_SYSTEM_LICENSE_INVALID_STATUS: 'keySystemLicenseInvalidStatus',
   KEY_SYSTEM_LICENSE_REQUEST_FAILED: 'keySystemLicenseRequestFailed',
+  KEY_SYSTEM_NO_ACCESS: 'keySystemNoAccess',
+  KEY_SYSTEM_NO_KEYS: 'keySystemNoKeys',
+  KEY_SYSTEM_NO_SESSION: 'keySystemNoSession',
   // Identifier for a manifest load error - data: { url : faulty URL, response : { code: error code, text: error text }}
   MANIFEST_LOAD_ERROR: 'manifestLoadError',
   // Identifier for a manifest load timeout - data: { url : faulty URL, response : { code: error code, text: error text }}


### PR DESCRIPTION
### This PR will...

try to adding an ability for HLS.js to detect the KeyStatus change event, so that we can know whether HDCP works or not.

as https://w3c.github.io/encrypted-media/#mediakeystatusmap-interface said, only `usable` key statuses is a valid one for DRM content to continue. once we receive a status change event without `usable` value, we'd better stop playing immediately, show a DRM-restriction message to users, or requesting a lower level of HDCP license URL.

like what it does for us:
when we are requesting DRM content and license staging URL with `HDCP=0`, there is no issue while I'm connecting my display with a non-HDCP support device.
![image](https://user-images.githubusercontent.com/5073227/82863823-aeaf9300-9f55-11ea-96cc-c6f968f538ed.png)

and for `HDCP=1` or `HDCP=2`, it will throw out `Error: keyStatusesError` (my customized error).
![image](https://user-images.githubusercontent.com/5073227/82863899-df8fc800-9f55-11ea-9512-302283fc33c4.png)

so the usage can be
```
hls.on('error', (error) => {
  if (error.detail === keyStatusesError) {
    // do something
    // maybe you can detach media and retach media with lower level HDCP request here.
  }
})
```

[Diagram to show you how the workflow works]
![tubi-hdcp](https://user-images.githubusercontent.com/5073227/83238012-5a601980-a1c8-11ea-8486-d942639984df.png)

[Corresponding UI]
![Kapture 2020-05-29 at 16 22 26](https://user-images.githubusercontent.com/5073227/83238252-be82dd80-a1c8-11ea-92fa-7b0156e3ad96.gif)

### Why is this Pull Request needed?

because HLS.js will keep playing contents even key status is a not valid one, we'll need to handle HDCP detection by ourselves first.

also, appending new error types to the HLS system. and we can receive the error message and do whatever we want in the HDCP-restricted condition then.

### Are there any points in the code the reviewer needs to double-check?

n/a

### Resolves issues:

n/a

### Checklist

- [x] changes have been done against the master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
